### PR TITLE
add: 添加EMAIL_CODE_TYPE属性，默认值为"API"

### DIFF
--- a/api.py
+++ b/api.py
@@ -1246,6 +1246,7 @@ class ConfigModel(BaseModel):
     EMAIL_DOMAINS: str
     EMAIL_USERNAME: str
     EMAIL_PIN: str
+    EMAIL_CODE_TYPE: Optional[str] = "API"  # 添加EMAIL_CODE_TYPE属性，默认值为"API"
     BROWSER_PATH: Optional[str] = None
     CURSOR_PATH: Optional[str] = None
     USE_PROXY: Optional[bool] = False


### PR DESCRIPTION
fix 'ConfigModel' object has no attribute 'EMAIL_CODE_TYPE'